### PR TITLE
Avoid emitting new block events bursts during sync

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -3,7 +3,8 @@
     "websocketApiUrl": "ws://localhost:8546"
   },
   "events": {
-    "maxAddresses": 10
+    "maxAddresses": 10,
+    "throttleNewBlocks": 1000
   },
   "logger": {
     "Papertrail": {


### PR DESCRIPTION
When the parser is syncing, the "new block" events are sent to the API/subscribers only once per second (default).

This avoids any subscriber to receive many (100/200 per sec) events as this may crash their processes.